### PR TITLE
Add YRPI token manifest and logo URI

### DIFF
--- a/tokens/custom/YRPI/token.json
+++ b/tokens/custom/YRPI/token.json
@@ -1,0 +1,12 @@
+{
+  "chainId": 8453,
+  "address": "0xf0e71975ed873d435837c53554a4373edc72015a",
+  "name": "Suht Yr Pi Hool",
+  "symbol": "YRPI",
+  "decimals": 18,
+  "logoURI": "https://drive.google.com/uc?export=download&id=1cQ7dOe0dpJuMd3pPaQ8GxaAD3sxKYMMj",
+  "extensions": {
+    "bridge": "supported_bridge_name",
+    "dexes": ["Uniswap", "SushiSwap"]
+  }
+}


### PR DESCRIPTION
Request to add base blockchain token "Suht Yr Pi Hool ($YrPi)" to Rango list of tokens.  

{
  "chainId": 8453,
  "address": "0xf0e71975ed873d435837c53554a4373edc72015a",
  "name": "Suht Yr Pi Hool",
  "symbol": "YRPI",
  "decimals": 18,
  "logoURI": "https://drive.google.com/uc?export=download&id=1cQ7dOe0dpJuMd3pPaQ8GxaAD3sxKYMMj",
  "extensions": {
    "bridge": "supported_bridge_name",
    "dexes": ["Uniswap", "SushiSwap"]
  }
}