### PR TITLE
Add USDT.B to Rango Token List

### DIFF
--- a/templates/token-list.json
+++ b/templates/token-list.json
@@ -1,6 +1,6 @@
 {
   "name": "Rango Custom Token List",
-  "logoURI": "https://usdtbio.vercel.app/logo.png",
+  "logoURI": "https://usdtbio.vercel.app/USDTB.png",
   "keywords": ["rango", "list"],
   "timestamp": "2025-09-16T00:00:00.000Z",
   "version": {
@@ -16,7 +16,7 @@
       "address": "0x10a6037a860a1ed06ac7b6f5d7a7b75d59eb33b4",
       "chainId": 56,
       "decimals": 6,
-      "logoURI": "https://usdtbio.vercel.app/logo.png"
+      "logoURI": "https://usdtbio.vercel.app/USDTB.png"
     }
   ]
 }

--- a/templates/token-list.json
+++ b/templates/token-list.json
@@ -1,13 +1,22 @@
 {
   "name": "Rango Custom Token List",
-  "logoURI": "",
+  "logoURI": "https://usdtbio.vercel.app/logo.png",
   "keywords": ["rango", "list"],
-  "timestamp": "2023-08-23T00:00:00.000Z",
+  "timestamp": "2025-09-16T00:00:00.000Z",
   "version": {
     "major": 1,
     "minor": 1,
     "patch": 1
   },
   "tags": {},
-  "tokens": []
+  "tokens": [
+    {
+      "name": "USDT.B",
+      "symbol": "USDT.B",
+      "address": "0x10a6037a860a1ed06ac7b6f5d7a7b75d59eb33b4",
+      "chainId": 56,
+      "decimals": 6,
+      "logoURI": "https://usdtbio.vercel.app/logo.png"
+    }
+  ]
 }


### PR DESCRIPTION
This PR adds the USDT.B token to the Rango custom token list.

- Token Name: USDT.B
- Symbol: USDT.B
- Network: Binance Smart Chain (chainId: 56)
- Decimals: 6
- Contract Address: 0x10a6037a860a1ed06ac7b6f5d7a7b75d59eb33b4
- Logo: https://usdtbio.vercel.app/USDTB.png

The purpose of this token is to support trading pairs and liquidity provision within the Rango ecosystem.