### PR TITLE
Add PUPCUP (Pup Cup) on Base to custom token list

### DIFF
--- a/tokens/custom/pupcup/manifest.json
+++ b/tokens/custom/pupcup/manifest.json
@@ -1,0 +1,9 @@
+[
+  {
+    "name": "Pup Cup",
+    "symbol": "PUPCUP",
+    "address": "0x42BAb297f90e6285546F05abdF4C42D8415E9794",
+    "chainId": 8453,
+    "decimals": 18
+  }
+]


### PR DESCRIPTION
## Add PUPCUP (Pup Cup) on Base to Rango custom token list

| Field | Value |
|---|---|
| Name | Pup Cup |
| Symbol | PUPCUP |
| Chain ID | 8453 (Base) |
| Address | `0x42BAb297f90e6285546F05abdF4C42D8415E9794` |
| Decimals | 18 |
| Website | https://theanvil.xyz |
| Basescan | https://basescan.org/token/0x42bab297f90e6285546f05abdf4c42d8415e9794 |

Source verified ✅ | 0% tax ✅ | LP locked 2027 ✅ | Active Uniswap V3 liquidity ✅